### PR TITLE
Fix CVE-2024-43688, buffer underflow for very large step values

### DIFF
--- a/entry.c
+++ b/entry.c
@@ -582,7 +582,10 @@ get_number(int *numptr, int low, const char *names[], int ch, FILE *file,
 		/* got a number, check for valid terminator */
 		if (!strchr(terms, ch))
 			goto bad;
-		*numptr = atoi(temp);
+		i = atoi(temp);
+		if (i < 0)
+			goto bad;
+		*numptr = i;
 		return (ch);
 	}
 
@@ -635,7 +638,7 @@ set_range(bitstr_t *bits, int low, int high, int start, int stop, int step) {
 	start -= low;
 	stop -= low;
 
-	if (step == 1) {
+	if (step <= 1 || step > stop) {
 		bit_nset(bits, start, stop);
 	} else {
 		for (int i = start; i <= stop; i += step)


### PR DESCRIPTION
In get_number(), reject values that are so large that they are interpreted as negative numbers.  In set_range(), step values smaller than one or larger than the "stop" value are ignored.  This prevents bit_nset() from being called with out-of-range values.

Bug found by Dave G. of Supernetworks.